### PR TITLE
saner flags for virtualenv

### DIFF
--- a/dploi_fabric/virtualenv.py
+++ b/dploi_fabric/virtualenv.py
@@ -7,12 +7,12 @@ def update():
     """
     updates a virtualenv (pip install requirements.txt)
     """
-    do_run('cd %(path)s; bin/pip install -r requirements.txt --upgrade' % config.sites["main"].deployment)
+    do_run('cd %(path)s; bin/pip install -r requirements.txt' % config.sites["main"].deployment)
 
 @task
 def create():
     """
     creates a virtualenv and calls update
     """
-    do_run('cd %(path)s; virtualenv . --system-site-packages' % config.sites["main"].deployment)
+    do_run('cd %(path)s; virtualenv .' % config.sites["main"].deployment)
     update()


### PR DESCRIPTION
Don't use `--upgrade` when updating, so it doesn't re-download everything on each deploy (`--upgrade` makes it hit the net and re-download everything even if it's pinned and installed).

Don't use `--system-site-packages` to properly have properly isolated environments.
