### PR TITLE
fixes #23

### DIFF
--- a/dploi_fabric/utils.py
+++ b/dploi_fabric/utils.py
@@ -218,7 +218,7 @@ class Configuration(object):
         if site_dict.gunicorn['bind']:
             bind = site_dict.gunicorn['bind']
         else:
-            bind = 'socket:{}'.format(socket)
+            bind = 'unix:{}'.format(socket)
         gunicorn_cmd_context = {
             "socket": socket,
             "bind": bind,


### PR DESCRIPTION
```Error: '/home/cmsplayground-dev/tmp/cmsplayground-dev_main_gunicorn.sock' is not a valid port number```

gunicorn socket path should start with ```unix```